### PR TITLE
Adding logger to support debug for underlying library.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,8 @@
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.owasp/dependency-check-core "1.3.6"]
-                 [org.owasp/dependency-check-utils "1.3.6"]]
+                 [org.owasp/dependency-check-utils "1.3.6"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [org.slf4j/slf4j-log4j12 "1.7.1"]
+                 [log4j/log4j "1.2.17"]]
   :eval-in-leiningen true)

--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -3,9 +3,20 @@
   (:import (org.owasp.dependencycheck Engine)
            (org.owasp.dependencycheck.utils Settings Settings$KEYS)
            (org.owasp.dependencycheck.data.nvdcve CveDB)
-           (org.owasp.dependencycheck.reporting ReportGenerator ReportGenerator$Format)))
+           (org.owasp.dependencycheck.reporting ReportGenerator ReportGenerator$Format)
+		   (org.apache.log4j PropertyConfigurator)))
 
 (defonce SUPPRESSION_FILE "suppression.xml")
+(defonce SOURCE_DIR       "src")
+(defonce LOG_CONF_FILE    "log4j.properties")
+
+(defn reconfigure-log4j
+  "Reconfigures log4j from a log4j.properties file"
+  []
+  (let [config-file (io/file SOURCE_DIR LOG_CONF_FILE)]
+    (when (.exists config-file)
+	   (prn "Reconfiguring log4j")
+	   (PropertyConfigurator/configure (.getPath config-file)))))
 
 (defn- db-properties
   "Returns the CVE database properties"
@@ -77,6 +88,7 @@
 (defn main
   "Scans the JAR files found on the class path and creates a vulnerability report."
   [project-classpath project-name output-format output-directory]
+  (reconfigure-log4j)
   (let [format-key (-> output-format read-string report-format)]
     (-> project-classpath
         target-files

--- a/src/log4j.properties
+++ b/src/log4j.properties
@@ -1,0 +1,6 @@
+log4j.rootLogger=OFF, console
+log4j.logger.org.livingsocial=INFO
+log4j.logger.org.owasp.dependencycheck=ERROR
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
We needed a facility to expose logging for the underlying owasp library for debug purposes. I was not really happy about hardcoding path and log4j dependency, but because the plugin launches without project classpath it seemed better convention.

I decided to hardcode the configuration file location instead of relying on facilities in clojure, as the logging tools API assumes configuration is available in clojure classpath. While it may be possible to fake the classpath loading and work backwards it hardly seems worth the effort to get logging functionality.