### PR TITLE
Project map options to log or throw vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 0.1.3`
 
 Add `[com.livingsocial/lein-dependency-check "0.1.3"]` to the `:plugins` vector of your project.clj.
 
+Project-level configuration may be provided under a `:dependency-check` key in your project.clj. Currently supported options are:
+ * `:log` log each vulnerability found to stdout
+ * `:throw` throw an exception after analysis and reporting if vulnerabilities are found, eg. to fail a build
+
 ## Usage
 
 To generate a `dependency-check-report.html` report file to the current project's `target` directory, run:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.livingsocial/lein-dependency-check "0.1.3"
+(defproject com.livingsocial/lein-dependency-check "0.1.4-SNAPSHOT"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.livingsocial/lein-dependency-check "0.1.4-SNAPSHOT"
+(defproject com.livingsocial/lein-dependency-check "0.2.0-SNAPSHOT"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/src/leiningen/dependency_check.clj
+++ b/src/leiningen/dependency_check.clj
@@ -23,7 +23,8 @@
   ([project output-format] (dependency-check project output-format "target"))
   ([project output-format output-directory]
    (let [classpath (cp/get-classpath project)
-         name      (:name project)]
+         name      (:name project)
+         config    (:dependency-check project)]
      (eval/eval-in-project (dependency-check-project project)
-                           `(lein-dependency-check.core/main '~classpath '~name '~output-format '~output-directory)
+                           `(lein-dependency-check.core/main '~classpath '~name '~output-format '~output-directory '~config)
                            '(require 'lein-dependency-check.core)))))


### PR DESCRIPTION
This update allows a user to declare whether to log found vulnerabilities and/or throw an exception at end of processing if any vulnerabilities are found. That makes it much more useful for me as a scheduled build plugin.

I added the config to the project.clj instead of as command line args because the command-line args approach would require some potentially breaking rework of the existing command line arguments.

Project version bumped to 0.2.0-SNAPSHOT as this adds a minor feature. Not sure what your release process is so this may not be correct?

Fixes #6 
Fixes #5 

Wasn't sure how to go about unit testing this. Installing this branch locally and testing on a minimal project with a vulnerable dep:

## No `:dependency-check` config in project.clj
```bash
[paul@Unknown-60-6c-66-2a-db-9a foo]$ lein dependency-check
"Scanning" 5 "file(s)..."
"Scanning file" "/home/paul/.m2/repository/org/clojure/clojure/1.8.0/clojure-1.8.0.jar"
"Scanning file" "/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar"
"Scanning file" "/home/paul/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar"
"Scanning file" "/home/paul/.m2/repository/clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar"
"Done."
"Analyzing dependencies..."
"Done."
"Generating report..."
"Done."
[paul@Unknown-60-6c-66-2a-db-9a foo]$
```

## With `:log` only in `:dependency-check`
```bash
[paul@Unknown-60-6c-66-2a-db-9a foo]$ lein dependency-check
"Scanning" 5 "file(s)..."
"Scanning file" "/home/paul/.m2/repository/org/clojure/clojure/1.8.0/clojure-1.8.0.jar"
"Scanning file" "/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar"
"Scanning file" "/home/paul/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar"
"Scanning file" "/home/paul/.m2/repository/clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar"
"Done."
"Analyzing dependencies..."
"Done."
"Generating report..."
"Done."
"Vulnerable Dependency:" "Dependency{ fileName='commons-beanutils-1.8.0.jar', actualFilePath='/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar', filePath='/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar'}"
[paul@Unknown-60-6c-66-2a-db-9a foo]$ 
```

## With `:throw` in `:dependency-check`
```bash
[paul@Unknown-60-6c-66-2a-db-9a foo]$ lein dependency-check
"Scanning" 5 "file(s)..."
"Scanning file" "/home/paul/.m2/repository/org/clojure/clojure/1.8.0/clojure-1.8.0.jar"
"Scanning file" "/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar"
"Scanning file" "/home/paul/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar"
"Scanning file" "/home/paul/.m2/repository/clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar"
"Done."
"Analyzing dependencies..."
"Done."
"Generating report..."
"Done."
Exception in thread "main" clojure.lang.ExceptionInfo: Vulnerable Dependencies! {:vulnerable (#object[org.owasp.dependencycheck.dependency.Dependency 0x2575f671 "Dependency{ fileName='commons-beanutils-1.8.0.jar', actualFilePath='/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar', filePath='/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar'}"])}, compiling:(/tmp/form-init5298508938903603170.clj:1:73)
	at clojure.lang.Compiler.load(Compiler.java:7391)
	at clojure.lang.Compiler.loadFile(Compiler.java:7317)
	at clojure.main$load_script.invokeStatic(main.clj:275)
	at clojure.main$init_opt.invokeStatic(main.clj:277)
	at clojure.main$init_opt.invoke(main.clj:277)
	at clojure.main$initialize.invokeStatic(main.clj:308)
	at clojure.main$null_opt.invokeStatic(main.clj:342)
	at clojure.main$null_opt.invoke(main.clj:339)
	at clojure.main$main.invokeStatic(main.clj:421)
	at clojure.main$main.doInvoke(main.clj:384)
	at clojure.lang.RestFn.invoke(RestFn.java:421)
	at clojure.lang.Var.invoke(Var.java:383)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.Var.applyTo(Var.java:700)
	at clojure.main.main(main.java:37)
Caused by: clojure.lang.ExceptionInfo: Vulnerable Dependencies! {:vulnerable (#object[org.owasp.dependencycheck.dependency.Dependency 0x2575f671 "Dependency{ fileName='commons-beanutils-1.8.0.jar', actualFilePath='/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar', filePath='/home/paul/.m2/repository/commons-beanutils/commons-beanutils/1.8.0/commons-beanutils-1.8.0.jar'}"])}
	at clojure.core$ex_info.invokeStatic(core.clj:4617)
	at clojure.core$ex_info.invoke(core.clj:4617)
	at lein_dependency_check.core$throw_exception_on_vulnerability.invokeStatic(core.clj:96)
	at lein_dependency_check.core$throw_exception_on_vulnerability.invoke(core.clj:88)
	at lein_dependency_check.core$main.invokeStatic(core.clj:109)
	at lein_dependency_check.core$main.invoke(core.clj:99)
	at user$eval53.invokeStatic(form-init5298508938903603170.clj:1)
	at user$eval53.invoke(form-init5298508938903603170.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:6927)
	at clojure.lang.Compiler.eval(Compiler.java:6917)
	at clojure.lang.Compiler.load(Compiler.java:7379)
	... 14 more
Subprocess failed
[paul@Unknown-60-6c-66-2a-db-9a foo]$ 
```