### PR TITLE
Fix/dep check version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.livingsocial/lein-dependency-check "0.2.0"
+(defproject com.livingsocial/lein-dependency-check "0.2.1-SNAPSHOT"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "The MIT License (MIT)"
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.owasp/dependency-check-core "1.3.6"]
-                 [org.owasp/dependency-check-utils "1.3.6"]
+                 [org.owasp/dependency-check-core "1.4.5"]
+                 [org.owasp/dependency-check-utils "1.4.5"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-log4j12 "1.7.1"]
                  [log4j/log4j "1.2.17"]]


### PR DESCRIPTION
Update to latest version of dep-check project for better logging, bugfixes. Bumped project version to 0.2.1-SNAPSHOT.

No deviation from existing behaviour on my projects.

Fixes #8