### PR TITLE
Feature/document found vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A Leiningen plugin for detecting vulnerable project dependencies. Basic clojure 
 To run dependency-check without having to add it to every Leiningen project as a project-level plugin,
 add dependency-check to the `:plugins` vector of your `:user` profile. E.g., a `~/.lein/profiles.clj` with dependency-check as a plugin -
 ```
-{:user {:plugins [[com.livingsocial/lein-dependency-check "0.1.3"]]}}
+{:user {:plugins [[com.livingsocial/lein-dependency-check "0.2.1"]]}}
 ```
 
-If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 0.1.3`.
+If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 0.2.1`.
 
 ### As a Project-Level Plugin:
 
-Add `[com.livingsocial/lein-dependency-check "0.1.3"]` to the `:plugins` vector of your project.clj.
+Add `[com.livingsocial/lein-dependency-check "0.2.1"]` to the `:plugins` vector of your project.clj.
 
 Project-level configuration may be provided under a `:dependency-check` key in your project.clj. Currently supported options are:
  * `:log` log each vulnerability found to stdout

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A Leiningen plugin for detecting vulnerable project dependencies. Basic clojure 
 To run dependency-check without having to add it to every Leiningen project as a project-level plugin,
 add dependency-check to the `:plugins` vector of your `:user` profile. E.g., a `~/.lein/profiles.clj` with dependency-check as a plugin -
 ```
-{:user {:plugins [[com.livingsocial/lein-dependency-check "0.2.1"]]}}
+{:user {:plugins [[com.livingsocial/lein-dependency-check "0.2.2"]]}}
 ```
 
-If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 0.2.1`.
+If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 0.2.2`.
 
 ### As a Project-Level Plugin:
 
-Add `[com.livingsocial/lein-dependency-check "0.2.1"]` to the `:plugins` vector of your project.clj.
+Add `[com.livingsocial/lein-dependency-check "0.2.2"]` to the `:plugins` vector of your project.clj.
 
 Project-level configuration may be provided under a `:dependency-check` key in your project.clj. Currently supported options are:
  * `:log` log each vulnerability found to stdout

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.livingsocial/lein-dependency-check "0.2.1"
+(defproject com.livingsocial/lein-dependency-check "0.2.2-SNAPSHOT"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -87,9 +87,10 @@
 
 (defn- throw-exception-on-vulnerability [engine {:keys [log throw]}]
   (.cleanup engine)
-  (when-let [vulnerable-dependencies (seq (filter
-                                           #((complement empty?) (.getVulnerabilities %))
-                                           (.getDependencies engine)))]
+  (when-let [vulnerable-dependencies (->> (.getDependencies engine)
+                                          (filter #((complement empty?) (.getVulnerabilities %)))
+                                          (map (fn [dep] {:dependency dep
+                                                          :vulnerabilities (.getVulnerabilities dep)})))]
     (when log
       (doall (map #(prn "Vulnerable Dependency:" (.toString %)) vulnerable-dependencies)))
     (when throw


### PR DESCRIPTION
Augment the exception and log output to include details of the
vulnerabilities found, not just the dependendencies that have
vulnerabilities. This is useful when trying to assess the impact of a vulnerability.

Bumped version to 0.2.2-SNAPSHOT, bumped versions in docs assuming release will be 0.2.2