### PR TITLE
call seq on vec of vulns to get nil for when-let check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.livingsocial/lein-dependency-check "0.2.2"
+(defproject com.livingsocial/lein-dependency-check "0.2.3-SNAPSHOT"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -90,7 +90,8 @@
   (when-let [vulnerable-dependencies (->> (.getDependencies engine)
                                           (filter #((complement empty?) (.getVulnerabilities %)))
                                           (map (fn [dep] {:dependency dep
-                                                          :vulnerabilities (.getVulnerabilities dep)})))]
+                                                          :vulnerabilities (.getVulnerabilities dep)}))
+                                          seq)]
     (when log
       (doall (map #(prn "Vulnerable Dependency:" (.toString %)) vulnerable-dependencies)))
     (when throw


### PR DESCRIPTION
Fixes #11 

With no vulnerable deps:

```
[paul@localhost crucible]$ lein dependency-check
Retrieving cheshire/cheshire/5.7.0/cheshire-5.7.0.pom from clojars
Retrieving com/fasterxml/jackson/core/jackson-core/2.8.6/jackson-core-2.8.6.pom from central
Retrieving com/fasterxml/jackson/jackson-parent/2.8/jackson-parent-2.8.pom from central
Retrieving com/fasterxml/oss-parent/27/oss-parent-27.pom from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.8.6/jackson-dataformat-smile-2.8.6.pom from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformats-binary/2.8.6/jackson-dataformats-binary-2.8.6.pom from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.8.6/jackson-dataformat-cbor-2.8.6.pom from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.8.6/jackson-dataformat-smile-2.8.6.jar from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.8.6/jackson-dataformat-cbor-2.8.6.jar from central
Retrieving com/fasterxml/jackson/core/jackson-core/2.8.6/jackson-core-2.8.6.jar from central
Retrieving cheshire/cheshire/5.7.0/cheshire-5.7.0.jar from clojars
"Scanning" 14 "file(s)..."
"Scanning file" "/home/paul/.m2/repository/tigris/tigris/0.1.1/tigris-0.1.1.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/core.specs.alpha/0.1.10/core.specs.alpha-0.1.10.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/clojure/1.9.0-alpha17/clojure-1.9.0-alpha17.jar"
"Scanning file" "/home/paul/.m2/repository/clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar"
"Scanning file" "/home/paul/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.8.6/jackson-dataformat-cbor-2.8.6.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.cli/0.3.5/tools.cli-0.3.5.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.namespace/0.2.11/tools.namespace-0.2.11.jar"
"Scanning file" "/home/paul/.m2/repository/camel-snake-kebab/camel-snake-kebab/0.4.0/camel-snake-kebab-0.4.0.jar"
"Scanning file" "/home/paul/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.8.6/jackson-dataformat-smile-2.8.6.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/test.check/0.9.0/test.check-0.9.0.jar"
"Scanning file" "/home/paul/.m2/repository/cheshire/cheshire/5.7.0/cheshire-5.7.0.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/spec.alpha/0.1.123/spec.alpha-0.1.123.jar"
"Scanning file" "/home/paul/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.8.6/jackson-core-2.8.6.jar"
"Done."
"Analyzing dependencies..."
"Done."
"Generating report..."
"Done."
[paul@localhost crucible]$
```

Reverting `cheshire` to introduce a vulnerable dependency:

```
[paul@localhost crucible]$ lein dependency-check
Retrieving cheshire/cheshire/5.6.0/cheshire-5.6.0.pom from clojars
Retrieving com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.pom from central
Retrieving com/fasterxml/jackson/jackson-parent/2.7/jackson-parent-2.7.pom from central
Retrieving com/fasterxml/oss-parent/25/oss-parent-25.pom from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.7.3/jackson-dataformat-smile-2.7.3.pom from central
Retrieving com/fasterxml/jackson/jackson-parent/2.7-1/jackson-parent-2.7-1.pom from central
Retrieving com/fasterxml/oss-parent/26/oss-parent-26.pom from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.7.3/jackson-dataformat-cbor-2.7.3.pom from central
Retrieving com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.jar from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.7.3/jackson-dataformat-cbor-2.7.3.jar from central
Retrieving com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.7.3/jackson-dataformat-smile-2.7.3.jar from central
Retrieving cheshire/cheshire/5.6.0/cheshire-5.6.0.jar from clojars
"Scanning" 14 "file(s)..."
"Scanning file" "/home/paul/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.7.3/jackson-dataformat-smile-2.7.3.jar"
"Scanning file" "/home/paul/.m2/repository/tigris/tigris/0.1.1/tigris-0.1.1.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/core.specs.alpha/0.1.10/core.specs.alpha-0.1.10.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/clojure/1.9.0-alpha17/clojure-1.9.0-alpha17.jar"
"Scanning file" "/home/paul/.m2/repository/clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.cli/0.3.5/tools.cli-0.3.5.jar"
"Scanning file" "/home/paul/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.7.3/jackson-dataformat-cbor-2.7.3.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/tools.namespace/0.2.11/tools.namespace-0.2.11.jar"
"Scanning file" "/home/paul/.m2/repository/camel-snake-kebab/camel-snake-kebab/0.4.0/camel-snake-kebab-0.4.0.jar"
"Scanning file" "/home/paul/.m2/repository/cheshire/cheshire/5.6.0/cheshire-5.6.0.jar"
"Scanning file" "/home/paul/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/test.check/0.9.0/test.check-0.9.0.jar"
"Scanning file" "/home/paul/.m2/repository/org/clojure/spec.alpha/0.1.123/spec.alpha-0.1.123.jar"
"Done."
"Analyzing dependencies..."
"Done."
"Generating report..."
"Done."
Exception in thread "main" clojure.lang.ExceptionInfo: Vulnerable Dependencies! {:vulnerable ({:dependency #object[org.owasp.dependencycheck.dependency.Dependency 0x6f95cd51 "Dependency{ fileName='jackson-core-2.7.3.jar', actualFilePath='/home/paul/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.jar', filePath='/home/paul/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.jar', packagePath='/home/paul/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.7.3/jackson-core-2.7.3.jar'}"], :vulnerabilities #{#object[org.owasp.dependencycheck.dependency.Vulnerability 0xc7a977f "Vulnerability CVE-2016-7051\nReferences:\n=> Reference: { name='97688', url='http://www.securityfocus.com/bid/97688', source='BID' }\n=> Reference: { name='https://bugzilla.redhat.com/show_bug.cgi?id=1378673', url='https://bugzilla.redhat.com/show_bug.cgi?id=1378673', source='CONFIRM' }\n=> Reference: { name='https://github.com/FasterXML/jackson-dataformat-xml/issues/211', url='https://github.com/FasterXML/jackson-dataformat-xml/issues/211', source='CONFIRM' }\n\nSoftware:\n=> VulnerableSoftware{cpe:/a:fasterxml:jackson:2.7.7[1]}\n=> VulnerableSoftware{cpe:/a:fasterxml:jackson:2.8.0[null]}\n=> VulnerableSoftware{cpe:/a:fasterxml:jackson:2.8.0:rc1[null]}\n=> VulnerableSoftware{cpe:/a:fasterxml:jackson:2.8.0:rc2[null]}\n=> VulnerableSoftware{cpe:/a:fasterxml:jackson:2.8.1[null]}\n=> VulnerableSoftware{cpe:/a:fasterxml:jackson:2.8.2[null]}\n=> VulnerableSoftware{cpe:/a:fasterxml:jackson:2.8.3[null]}\n"]}})}, compiling:(/tmp/form-init9054037742534819495.clj:1:73)
```