### PR TITLE
Update OWASP dependency check to version 3.1.0.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "The MIT License (MIT)"
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.owasp/dependency-check-core "3.0.1"]
-                 [org.owasp/dependency-check-utils "3.0.1"]
+                 [org.owasp/dependency-check-core "3.1.0"]
+                 [org.owasp/dependency-check-utils "3.1.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-log4j12 "1.7.1"]
                  [log4j/log4j "1.2.17"]]


### PR DESCRIPTION
Hi,

this PR updates the OWASP dependency check to version 3.1.0, which has a bugfix to the Maven central analyzer ([978](https://github.com/jeremylong/DependencyCheck/issues/978)) among other features.