### PR TITLE
Add CLI, support multiple formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Project-level configuration may be provided under a `:dependency-check` key in y
  * `properties-file` Specifies a file that contains properties to merge with default values
  * `output-format` Vector of desired output formats: xml, csv, json, html, vuln, all
  * `output-directory` Directory to output results to
+ * `suppression-file` Path to the suppression XML file
 
 ## Usage
 
@@ -51,6 +52,13 @@ To set throw error when vulnerabilities found:
 
     $ lein dependency-check --throw
 
+To set a suppression file
+
+    $ lein dependency-check --suppression-file /suppression.xml
+
+To set a properties file
+
+    $ lein dependency-check --properties-file /dependencycheck.properties
 
 ##  Suppressing False Positives
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Add `[com.livingsocial/lein-dependency-check "1.0.4"]` to the `:plugins` vector 
 Project-level configuration may be provided under a `:dependency-check` key in your project.clj. Currently supported options are:
  * `:log` log each vulnerability found to stdout
  * `:throw` throw an exception after analysis and reporting if vulnerabilities are found, eg. to fail a build
- * `:properties-file` properties file to merge with DependencyCheck settings
+ * `properties-file` Specifies a file that contains properties to merge with default values
+ * `output-format` Vector of desired output formats: xml, csv, json, html, vuln, all
+ * `output-directory` Directory to output results to
 
 ## Usage
 
@@ -31,11 +33,24 @@ To generate a `dependency-check-report.html` report file to the current project'
 
 To generate the report in XML format, run:
 
-    $ lein dependency-check :xml
+    $ lein dependency-check --output-format :xml
+
+To generate the report in multiple formats, run:
+
+    $ lein dependency-check --output-format :xml,:json,:html,:csv
 
 To write the report to a different directory (e.g., `/tmp`), run:
 
-    $ lein dependency-check :html /tmp
+    $ lein dependency-check --output-directory /tmp
+
+To set logging to stdout:
+
+    $ lein dependency-check --log
+
+To set throw error when vulnerabilities found:
+
+    $ lein dependency-check --throw
+
 
 ##  Suppressing False Positives
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ To set throw error when vulnerabilities found:
 
     $ lein dependency-check --throw
 
-To set a suppression file
+To set a suppression file:
 
     $ lein dependency-check --suppression-file /suppression.xml
 
-To set a properties file
+To set a properties file:
 
     $ lein dependency-check --properties-file /dependencycheck.properties
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def dependency-check-version "3.3.2")
 
-(defproject com.livingsocial/lein-dependency-check "1.1.0"
+(defproject com.livingsocial/lein-dependency-check "1.1.1"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"
@@ -8,6 +8,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.owasp/dependency-check-core ~dependency-check-version]
                  [org.owasp/dependency-check-utils ~dependency-check-version]
+                 [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-log4j12 "1.7.1"]
                  [log4j/log4j "1.2.17"]]

--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -7,7 +7,6 @@
            (org.owasp.dependencycheck.reporting ReportGenerator ReportGenerator$Format)
 		   (org.apache.log4j PropertyConfigurator)))
 
-(defonce SUPPRESSION_FILE "suppression.xml")
 (defonce SOURCE_DIR       "src")
 (defonce LOG_CONF_FILE    "log4j.properties")
 
@@ -28,10 +27,10 @@
 
 (defn- scan-files
   "Scans the specified files and returns the engine used to scan"
-  [files {:keys [properties-file]}]
+  [files {:keys [properties-file suppression-file]}]
   (let [settings (Settings.)
-        _ (when (.exists (io/as-file SUPPRESSION_FILE))
-            (.setString settings Settings$KEYS/SUPPRESSION_FILE SUPPRESSION_FILE))
+        _ (when (.exists (io/as-file suppression-file))
+            (.setString settings Settings$KEYS/SUPPRESSION_FILE suppression-file))
         _ (when properties-file
             (.mergeProperties settings properties-file))
         engine (Engine. settings)]

--- a/src/leiningen/dependency_check.clj
+++ b/src/leiningen/dependency_check.clj
@@ -14,12 +14,14 @@
     :parse-fn (fn [output-format]
                 (-> (string/replace output-format #":" "")
                     (string/split #",")))]
-   ["-o" "--output-directory DIR" "The folder to write to. The default is ./target"]])
+   ["-o" "--output-directory DIR" "The folder to write to. The default is ./target"]
+   ["-s" "--suppression-file FILE" "Path to the suppression XML file"]])
 
 (def ^:private cli-defaults
   "Default options."
   {:output-format ["html"]
    :output-directory "target"
+   :suppression-file "suppression.xml"
    :log false
    :throw false})
 

--- a/src/leiningen/dependency_check.clj
+++ b/src/leiningen/dependency_check.clj
@@ -11,12 +11,17 @@
    [nil "--throw" "throw error when vulnerabilities found"]
    ["-p" "--properties-file FILE" "Specificies a file that contains properties to merge with defaults."]
    ["-f" "--output-format FORMAT(S)" "The output format to write to (XML, HTML, CSV, JSON, VULN, ALL). Default is HTML"
-    :default ["html"]
     :parse-fn (fn [output-format]
                 (-> (string/replace output-format #":" "")
                     (string/split #",")))]
-   ["-o" "--output-directory DIR" "The folder to write to. The default is ./target"
-    :default "target"]])
+   ["-o" "--output-directory DIR" "The folder to write to. The default is ./target"]])
+
+(def cli-defaults
+  "Default options."
+  {:output-format ["html"]
+   :output-directory "target"
+   :log false
+   :throw false})
 
 (defn- dependency-check-project
   "Create a project to launch dependency-check, with only dependency-check as a dependency."
@@ -41,7 +46,8 @@
   [project & args]
   (let [classpath (cp/get-classpath project)
         name (:name project)
-        config (merge (:dependency-check project)
+        config (merge cli-defaults
+                      (:dependency-check project)
                       (:options (parse-opts args cli-options)))]
     (eval/eval-in-project (dependency-check-project project)
                           `(lein-dependency-check.core/main '~classpath '~name '~config)

--- a/src/leiningen/dependency_check.clj
+++ b/src/leiningen/dependency_check.clj
@@ -4,7 +4,7 @@
             [leiningen.core.classpath :as cp]
             [leiningen.core.eval :as eval]))
 
-(def cli-options
+(def ^:private cli-options
   "Command line options accepts:
   log, throw, output-format, output-directory, properties-file."
   [[nil "--log" "Log to stdout"]
@@ -16,7 +16,7 @@
                     (string/split #",")))]
    ["-o" "--output-directory DIR" "The folder to write to. The default is ./target"]])
 
-(def cli-defaults
+(def ^:private cli-defaults
   "Default options."
   {:output-format ["html"]
    :output-directory "target"


### PR DESCRIPTION
* CLI options merged with config options (CLI will overwrite config).
* Allow users to specify a suppression-file path in the config or with the --suppression-file command line option.
* Allow users to specify multiple output formats via a vector in the config or the --output-format command line option.