### PR TITLE
Pretty-print dependency information before throwing errors

### DIFF
--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -73,6 +73,7 @@
                            (map #(.getCvssScore %))
                            (apply max))]
         (when (>= max-score min-cvss)
+          (pprint vulnerable-dependencies)
           (throw (ex-info "Vulnerable Dependencies!" {:vulnerable vulnerable-dependencies}))))))
   engine)
 


### PR DESCRIPTION
Hi!

I use the Lein checker with:

```clojure
:dependency-check {:log false :throw true}
```

When it throws errors, the ex-info can be a humongous value, and not an easy one to pprint after-the-fact since it will have ` #object`s.

So I propose to pprint the info before the throwing.

One also could go one step beyond, and throw a thin, almost-empty error, for not duplicating the already-pprinted info. I doubt it would break anyone's workflow since it would be rare to programatically interact with Lein output.

Cheers - Victor