### PR TITLE
Issue #27: bump DC to 5.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A Leiningen plugin for detecting vulnerable project dependencies. Basic clojure 
 To run dependency-check without having to add it to every Leiningen project as a project-level plugin,
 add dependency-check to the `:plugins` vector of your `:user` profile. E.g., a `~/.lein/profiles.clj` with dependency-check as a plugin -
 ```
-{:user {:plugins [[com.livingsocial/lein-dependency-check "1.1.2"]]}}
+{:user {:plugins [[com.livingsocial/lein-dependency-check "1.1.3"]]}}
 ```
 
-If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 1.1.2`.
+If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 1.1.3`.
 
 ### As a Project-Level Plugin:
 
-Add `[com.livingsocial/lein-dependency-check "1.1.2"]` to the `:plugins` vector of your project.clj.
+Add `[com.livingsocial/lein-dependency-check "1.1.3"]` to the `:plugins` vector of your project.clj.
 
 Project-level configuration may be provided under a `:dependency-check` key in your project.clj. Currently supported options are:
  * `log` log each vulnerability found to stdout

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def dependency-check-version "3.3.2")
+(def dependency-check-version "5.2.1")
 
-(defproject com.livingsocial/lein-dependency-check "1.1.2"
+(defproject com.livingsocial/lein-dependency-check "1.1.3"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"


### PR DESCRIPTION
There's urgency to move to the latest version of dependency-check, as the NVD data XML feeds used by 3.3.2 will be retired October 9, 2019.