### PR TITLE
Update to use org.owasp/dependency-check:6.0.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def dependency-check-version "5.2.1")
+(def dependency-check-version "6.0.2")
 
-(defproject com.livingsocial/lein-dependency-check "1.1.4"
+(defproject com.livingsocial/lein-dependency-check "1.1.5-SNAPSHOT"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -3,10 +3,10 @@
             [clojure.pprint :refer [pprint]])
   (:import (org.owasp.dependencycheck Engine)
            (org.owasp.dependencycheck.dependency Vulnerability)
+           (org.owasp.dependencycheck.exception ExceptionCollection)
            (org.owasp.dependencycheck.utils Settings Settings$KEYS)
-           (org.owasp.dependencycheck.data.nvdcve CveDB)
-           (org.owasp.dependencycheck.reporting ReportGenerator ReportGenerator$Format)
-           (org.apache.log4j PropertyConfigurator)))
+           (org.apache.log4j PropertyConfigurator)
+           (java.io File)))
 
 (defonce SOURCE_DIR       "src")
 (defonce LOG_CONF_FILE    "log4j.properties")
@@ -14,7 +14,7 @@
 (defn reconfigure-log4j
   "Reconfigures log4j from a log4j.properties file"
   []
-  (let [config-file (io/file SOURCE_DIR LOG_CONF_FILE)]
+  (let [^File config-file (io/file SOURCE_DIR LOG_CONF_FILE)]
     (when (.exists config-file)
 	   (prn "Reconfiguring log4j")
 	   (PropertyConfigurator/configure (.getPath config-file)))))
@@ -28,7 +28,7 @@
 
 (defn- scan-files
   "Scans the specified files and returns the engine used to scan"
-  [files {:keys [properties-file suppression-file]}]
+  [files {:keys [^File properties-file suppression-file]}]
   (let [settings (Settings.)
         _ (when (.exists (io/as-file suppression-file))
             (.setString settings Settings$KEYS/SUPPRESSION_FILE suppression-file))
@@ -36,7 +36,7 @@
             (.mergeProperties settings properties-file))
         engine (Engine. settings)]
     (prn "Scanning" (count files) "file(s)...")
-    (doseq [file files]
+    (doseq [^File file files]
       (prn "Scanning file" (.getCanonicalPath file))
       (.scan engine file))
     (prn "Done.")
@@ -56,7 +56,7 @@
 (defn- write-report
   [engine report-name output-format output-directory]
   (doseq [format output-format]
-    (.writeReports engine report-name output-directory format))
+    (.writeReports engine report-name output-directory format (ExceptionCollection.)))
   engine)
 
 


### PR DESCRIPTION
This PR contains some updates to pull in the latest NIST vulnerability info, and removes some usages of deprecated functions in the upstream dependency-check library.  Currently, when running `lein dependency-check` at version 1.1.4, you get a message like:

```
2020-10-21 12:55:23,484 [main] ERROR org.owasp.dependencycheck.Engine  - Unable to download meta file: https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-modified.meta; received 404 -- resource not found
```

A full reproduction is here: https://github.com/jimberlage/lein-dependency-check-test/runs/1286835341?check_suite_focus=true

Updating the version of `org.owasp/dependency-check` to 6.0.2 pulls in the most up-to-date NIST files, at 1.1.  A validation of that fix is here: https://github.com/jimberlage/lein-dependency-check-test/runs/1286933269?check_suite_focus=true

Hopefully this helps, and thank you for your work on this very helpful project!

