### PR TITLE
Feature/6.5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 .DS_Store
 .idea/
 *.iml
+.lsp
+.clj-kondo

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A Leiningen plugin for detecting vulnerable project dependencies. Basic clojure 
 To run dependency-check without having to add it to every Leiningen project as a project-level plugin,
 add dependency-check to the `:plugins` vector of your `:user` profile. E.g., a `~/.lein/profiles.clj` with dependency-check as a plugin -
 ```
-{:user {:plugins [[com.livingsocial/lein-dependency-check "1.1.5"]]}}
+{:user {:plugins [[com.livingsocial/lein-dependency-check "1.2.0"]]}}
 ```
 
-If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 1.1.5`.
+If you are on Leiningen 1.x do `lein plugin install lein-dependency-check 1.2.0`.
 
 ### As a Project-Level Plugin:
 
-Add `[com.livingsocial/lein-dependency-check "1.1.5"]` to the `:plugins` vector of your project.clj.
+Add `[com.livingsocial/lein-dependency-check "1.2.0"]` to the `:plugins` vector of your project.clj.
 
 Project-level configuration may be provided under a `:dependency-check` key in your project.clj. Currently supported options are:
  * `log` log each vulnerability found to stdout

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def dependency-check-version "6.0.2")
+(def dependency-check-version "6.2.2")
 
-(defproject com.livingsocial/lein-dependency-check "1.1.5"
+(defproject com.livingsocial/lein-dependency-check "1.1.7"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def dependency-check-version "6.2.2")
 
-(defproject com.livingsocial/lein-dependency-check "1.1.7"
+(defproject com.livingsocial/lein-dependency-check "1.1.6"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,18 @@
-(def dependency-check-version "6.2.2")
+(def dependency-check-version "6.5.3")
 
-(defproject com.livingsocial/lein-dependency-check "1.1.6"
+(defproject com.livingsocial/lein-dependency-check "1.2.0"
   :description "Clojure command line tool for detecting vulnerable project dependencies"
   :url "https://github.com/livingsocial/lein-dependency-check"
   :license {:name "The MIT License (MIT)"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.owasp/dependency-check-core ~dependency-check-version]
                  [org.owasp/dependency-check-utils ~dependency-check-version]
-                 [org.clojure/tools.cli "0.4.1"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [org.slf4j/slf4j-log4j12 "1.7.1"]
-                 [log4j/log4j "1.2.17"]]
+                 [org.clojure/tools.cli "1.0.194"]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [org.slf4j/jcl-over-slf4j "1.7.30"]
+                 [org.slf4j/slf4j-api "1.7.32"]
+                 [org.apache.logging.log4j/log4j-api "2.17.1"]
+                 [org.apache.logging.log4j/log4j-slf4j-impl "2.14.1"]
+                 [org.apache.logging.log4j/log4j-core "2.17.1"]]
   :eval-in-leiningen true)

--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -5,19 +5,19 @@
            (org.owasp.dependencycheck.dependency Vulnerability)
            (org.owasp.dependencycheck.exception ExceptionCollection)
            (org.owasp.dependencycheck.utils Settings Settings$KEYS)
-           (org.apache.log4j PropertyConfigurator)
+           (org.apache.logging.log4j.core.config Configurator)
            (java.io File)))
 
 (defonce SOURCE_DIR       "src")
-(defonce LOG_CONF_FILE    "log4j.properties")
+(defonce LOG_CONF_FILE    "log4j2.xml")
 
 (defn reconfigure-log4j
-  "Reconfigures log4j from a log4j.properties file"
+  "Reconfigures log4j from a log4j2.xml file"
   []
   (let [^File config-file (io/file SOURCE_DIR LOG_CONF_FILE)]
     (when (.exists config-file)
 	   (prn "Reconfiguring log4j")
-	   (PropertyConfigurator/configure (.getPath config-file)))))
+     (Configurator/initialize nil (.getPath config-file)))))
 
 (defn- target-files
   "Selects the files to be scanned"
@@ -33,7 +33,7 @@
         _ (when (.exists (io/as-file suppression-file))
             (.setString settings Settings$KEYS/SUPPRESSION_FILE suppression-file))
         _ (when properties-file
-            (.mergeProperties settings  (io/as-file properties-file)))
+            (.mergeProperties settings ^File (io/as-file properties-file)))
         engine (Engine. settings)]
     (prn "Scanning" (count files) "file(s)...")
     (doseq [^File file files]

--- a/src/lein_dependency_check/core.clj
+++ b/src/lein_dependency_check/core.clj
@@ -33,7 +33,7 @@
         _ (when (.exists (io/as-file suppression-file))
             (.setString settings Settings$KEYS/SUPPRESSION_FILE suppression-file))
         _ (when properties-file
-            (.mergeProperties settings properties-file))
+            (.mergeProperties settings  (io/as-file properties-file)))
         engine (Engine. settings)]
     (prn "Scanning" (count files) "file(s)...")
     (doseq [^File file files]

--- a/src/log4j.properties
+++ b/src/log4j.properties
@@ -1,6 +1,0 @@
-log4j.rootLogger=OFF, console
-log4j.logger.org.livingsocial=INFO
-log4j.logger.org.owasp.dependencycheck=ERROR
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c %x - %m%n

--- a/src/log4j2.xml
+++ b/src/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%date [%thread] %-5p %logger %NDC - %message%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.livingsocial" level="INFO" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Logger name="owasp.dependencycheck" level="ERROR" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Root level="OFF">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
I updated the version of OWASP dependency check so this library can take advantage of the newest database schema.
I also removed log4j 1.2.x and migrated this to use log4j2, removed a cursive disambiguation warning and updated clojure dependencies.