### PR TITLE
Update dependency-check-core to 7.4.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def dependency-check-version "7.2.1")
+(def dependency-check-version "7.4.4")
 
 (defproject com.livingsocial/lein-dependency-check "1.4.0"
   :description "Clojure command line tool for detecting vulnerable project dependencies"


### PR DESCRIPTION
Please update `dependency-check-core` to fix column length problems with CVE-2020-36569.
https://github.com/jeremylong/DependencyCheck/pull/5229